### PR TITLE
fix("&&" to "||"): a image can not be both CV_8UC1 and CV_8UC3 at same

### DIFF
--- a/ch5/imageBasics/imageBasics.cpp
+++ b/ch5/imageBasics/imageBasics.cpp
@@ -22,7 +22,7 @@ int main ( int argc, char** argv )
     cv::imshow ( "image", image );      // 用cv::imshow显示图像
     cv::waitKey ( 0 );                  // 暂停程序,等待一个按键输入
     // 判断image的类型
-    if ( image.type() != CV_8UC1 && image.type() != CV_8UC3 )
+    if ( image.type() != CV_8UC1 || image.type() != CV_8UC3 )
     {
         // 图像类型不符合要求
         cout<<"请输入一张彩色图或灰度图."<<endl;


### PR DESCRIPTION
Fix a typo.

[   changes ] C:ch5/imageBasics.cpp
[ reference ] gaoxiang12/slambook.git
