### PR TITLE
should print Usage Message while launch it without input image

### DIFF
--- a/ch5/imageBasics/imageBasics.cpp
+++ b/ch5/imageBasics/imageBasics.cpp
@@ -7,6 +7,11 @@ using namespace std;
 
 int main ( int argc, char** argv )
 {
+    if(argc < 2)
+    {
+        cout << "Usage: ./imageBasics image_file_name" << endl;
+        return -1;
+    }
     // 读取argv[1]指定的图像
     cv::Mat image;
     image = cv::imread ( argv[1] ); //cv::imread函数读取指定路径下的图像


### PR DESCRIPTION
Ch4中的OpenCV进行基本的图像操作，当没有图像路径输入的时候，会提示一个不太明确的错误：
```
build git:(master) ./imageBasics 
terminate called after throwing an instance of 'std::logic_error' 
  what():  basic_string::_M_construct null not valid
[1]    12484 abort (core dumped)  ./imageBasics
```
这段错误应该是指的下面读取图像文件名称的时候，参数数组越界出错(argv)。
```
image = cv::imread ( argv[1] ); //cv::imread函数读取指定路径下的图像
```
在Main函数开始的时候添加适当的使用提示，比较清晰。