### PR TITLE
修复3D-3D变换估计的bug

### DIFF
--- a/ch7/pose_estimation_3d3d.cpp
+++ b/ch7/pose_estimation_3d3d.cpp
@@ -244,6 +244,15 @@ void pose_estimation_3d3d (
     Eigen::JacobiSVD<Eigen::Matrix3d> svd ( W, Eigen::ComputeFullU|Eigen::ComputeFullV );
     Eigen::Matrix3d U = svd.matrixU();
     Eigen::Matrix3d V = svd.matrixV();
+    
+    if (U.determinant() * V.determinant() < 0)
+	{
+        for (int x = 0; x < 3; ++x)
+        {
+            U(x, 2) *= -1;
+        }
+	}
+    
     cout<<"U="<<U<<endl;
     cout<<"V="<<V<<endl;
 


### PR DESCRIPTION
利用SVD求解3D-3D变换，需要U和V的行列式同号。换言之，旋转矩阵的行列式只能为1，不能为-1。