### PR TITLE
Update the new version of G2O interface.

### DIFF
--- a/ch6/g2o_curve_fitting/main.cpp
+++ b/ch6/g2o_curve_fitting/main.cpp
@@ -73,12 +73,20 @@ int main( int argc, char** argv )
     
     // 构建图优化，先设定g2o
     typedef g2o::BlockSolver< g2o::BlockSolverTraits<3,1> > Block;  // 每个误差项优化变量维度为3，误差值维度为1
-    Block::LinearSolverType* linearSolver = new g2o::LinearSolverDense<Block::PoseMatrixType>(); // 线性方程求解器
-    Block* solver_ptr = new Block( linearSolver );      // 矩阵块求解器
+
+    //-----修改以下注释到下行代码-----------//
+    // Block::LinearSolverType* linearSolver = new g2o::LinearSolverDense<Block::PoseMatrixType>(); // 线性方程求解器
+    std::unique_ptr<Block::LinearSolverType> linearSolver ( new g2o::LinearSolverDense<Block::PoseMatrixType>());
+
+    //-----修改以下注释到下行代码-----------//
+    //Block* solver_ptr = new Block( linearSolver );      // 矩阵块求解器
+    std::unique_ptr<Block> solver_ptr ( new Block ( std::move(linearSolver)));
+
     // 梯度下降方法，从GN, LM, DogLeg 中选
-    g2o::OptimizationAlgorithmLevenberg* solver = new g2o::OptimizationAlgorithmLevenberg( solver_ptr );
-    // g2o::OptimizationAlgorithmGaussNewton* solver = new g2o::OptimizationAlgorithmGaussNewton( solver_ptr );
-    // g2o::OptimizationAlgorithmDogleg* solver = new g2o::OptimizationAlgorithmDogleg( solver_ptr );
+    //-----修改以下注释到下行代码-----------//
+    // g2o::OptimizationAlgorithmLevenberg* solver = new g2o::OptimizationAlgorithmLevenberg( solver_ptr );
+    g2o::OptimizationAlgorithmLevenberg* solver = new g2o::OptimizationAlgorithmLevenberg ( std::move(solver_ptr));
+    
     g2o::SparseOptimizer optimizer;     // 图模型
     optimizer.setAlgorithm( solver );   // 设置求解器
     optimizer.setVerbose( true );       // 打开调试输出


### PR DESCRIPTION
新版的g2o（目前是2018年5月后的版本），BlockSover的构造器是unique_ptr的，unique_ptr不支持拷贝构造，所以传参必须通过move。


