### PR TITLE
Update visual_odometry.cpp

### DIFF
--- a/project/0.4/src/visual_odometry.cpp
+++ b/project/0.4/src/visual_odometry.cpp
@@ -298,7 +298,7 @@ void VisualOdometry::addMapPoints()
     {
         if ( matched[i] == true )   
             continue;
-        double d = ref_->findDepth ( keypoints_curr_[i] );
+        double d = curr_->findDepth ( keypoints_curr_[i] );
         if ( d<0 )  
             continue;
         Vector3d p_world = ref_->camera_->pixel2world (


### PR DESCRIPTION
When adding landmarks to the map, Z of landmarks should be queried in the current frame instead of the reference keyframe.
[experiment.pdf](https://github.com/gaoxiang12/slambook/files/7913196/experiment.pdf)

